### PR TITLE
Add CLI profile script for Kim DaeHyun

### DIFF
--- a/KimDaeHyun/cli-profile.py
+++ b/KimDaeHyun/cli-profile.py
@@ -1,0 +1,16 @@
+import click
+import pyfiglet
+from rich.console import Console
+
+@click.command()
+@click.option('--color', default='cyan', help='Color for the output text')
+@click.option('--message', default='Developer of CLIck-Me-Codex3', help='Custom message')
+def main(color, message):
+    """Display a simple CLI profile."""
+    console = Console()
+    ascii_art = pyfiglet.figlet_format('Kim DaeHyun')
+    console.print(ascii_art, style=color)
+    console.print(message, style=color)
+
+if __name__ == '__main__':
+    main()

--- a/KimDaeHyun/cli-profile.py
+++ b/KimDaeHyun/cli-profile.py
@@ -3,7 +3,7 @@ import pyfiglet
 from rich.console import Console
 
 @click.command()
-@click.option('--color', default='cyan', help='Color for the output text')
+@click.option('--color', type=click.Choice(['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'], case_sensitive=False), default='cyan', help='Color for the output text')
 @click.option('--message', default='Developer of CLIck-Me-Codex3', help='Custom message')
 def main(color, message):
     """Display a simple CLI profile."""

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
 
 # Install dependencies from requirements.txt
 pip install -r requirements.txt
+```
 
 ## Usage
 
 Run the profile command with:
 
 ```bash
-python profile.py
+python KimDaeHyun/cli-profile.py --color magenta --message "Hello from Click"
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click
+pyfiglet
+rich


### PR DESCRIPTION
## Summary
- add a minimal CLI profile script using click, pyfiglet and rich
- document usage in README
- list requirements

## Testing
- `python -m py_compile KimDaeHyun/cli-profile.py`
- `python KimDaeHyun/cli-profile.py --color red --message test` *(fails: ModuleNotFoundError: No module named 'pyfiglet')*
- `pip install click pyfiglet rich` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688737a78870832786577a355bc70bdd