### PR TITLE
Refactor CLI script and extend README

### DIFF
--- a/KimDaeHyun/cli-profile.py
+++ b/KimDaeHyun/cli-profile.py
@@ -2,15 +2,36 @@ import click
 import pyfiglet
 from rich.console import Console
 
+
+class ProfileCLI:
+    """Simple class to display a CLI profile."""
+
+    def __init__(self):
+        self.console = Console()
+
+    def display_profile(self, color: str, message: str) -> None:
+        """Render the profile using Rich and PyFiglet."""
+        ascii_art = pyfiglet.figlet_format('Kim DaeHyun')
+        self.console.print(ascii_art, style=color)
+        self.console.print(message, style=color)
+
+
 @click.command()
-@click.option('--color', type=click.Choice(['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'], case_sensitive=False), default='cyan', help='Color for the output text')
+@click.option(
+    '--color',
+    type=click.Choice(
+        ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'],
+        case_sensitive=False,
+    ),
+    default='cyan',
+    help='Color for the output text',
+)
 @click.option('--message', default='Developer of CLIck-Me-Codex3', help='Custom message')
-def main(color, message):
-    """Display a simple CLI profile."""
-    console = Console()
-    ascii_art = pyfiglet.figlet_format('Kim DaeHyun')
-    console.print(ascii_art, style=color)
-    console.print(message, style=color)
+def main(color: str, message: str) -> None:
+    """Entry point for the CLI command."""
+    cli = ProfileCLI()
+    cli.display_profile(color, message)
+
 
 if __name__ == '__main__':
     main()

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 CLIck-Me-Codex3 is a minimal command line interface built with [Click](https://click.palletsprojects.com/) that displays a short profile.
 
+## Technology Stack
+
+| Language/Framework | Usage | Notes |
+|--------------------|-------|-------|
+| Python             | Core development language | |
+| Click              | Command line interface | |
+| Rich               | Console formatting | |
+| PyFiglet           | ASCII art generation | |
+
 ## Setup
 
 Ensure Python 3.10 or later is installed. It's highly recommended to work within a virtual environment.
@@ -22,3 +31,9 @@ Run the profile command with:
 ```bash
 python KimDaeHyun/cli-profile.py --color magenta --message "Hello from Click"
 ```
+
+## Previous Projects
+
+| Project Name | Description | Link |
+|--------------|-------------|------|
+| | | |


### PR DESCRIPTION
## Summary
- refactor `cli-profile.py` into a simple `ProfileCLI` class
- document technology stack
- add previous projects table

## Testing
- `python -m py_compile KimDaeHyun/cli-profile.py`

------
https://chatgpt.com/codex/tasks/task_e_68873bf13c0c8327a6cbc579f314ef15